### PR TITLE
Allow passing a external animation controller

### DIFF
--- a/lib/shimmer_animation.dart
+++ b/lib/shimmer_animation.dart
@@ -17,6 +17,7 @@ import 'package:shimmer_animation/src/shimmer_animator.dart';
 /// - [duration] : accepts a [Duration] that would be the time period of animation. Default value is [Duration(seconds: 3)]
 /// - [interval] : accepts a [Duration] that would be the interval between the repeating animation. Default value is [Duration(seconds: 0)]
 /// - [direction] : accepts a [ShimmerDirection] and aligns the animation accordingly. Default value is [ShimmerDirection.fromLBRT()]
+/// - [animationController] : accepts a [AnimationController]. Recommended to use when multiple shimmer animations are used in a single screen.
 class Shimmer extends StatelessWidget {
   /// Accepts a child [Widget] over which the animation is to be displayed
   final Widget child;
@@ -39,6 +40,9 @@ class Shimmer extends StatelessWidget {
   /// Accepts a [ShimmerDirection] and aligns the animation accordingly. Default value is [ShimmerDirection.fromLBRT()]
   final ShimmerDirection direction;
 
+  /// Accepts a [AnimationController]. Recommended to use when multiple shimmer animations are used in a single screen.
+  final AnimationController? animationController;
+
   Shimmer({
     required this.child,
     this.enabled = true,
@@ -47,6 +51,7 @@ class Shimmer extends StatelessWidget {
     this.duration = const Duration(seconds: 3),
     this.interval = const Duration(seconds: 0),
     this.direction = const ShimmerDirection.fromLTRB(),
+    this.animationController,
   });
 
   @override
@@ -59,6 +64,7 @@ class Shimmer extends StatelessWidget {
         duration: duration,
         interval: interval,
         direction: direction,
+        controller: animationController,
       );
     else
       return child;
@@ -127,10 +133,8 @@ class ShimmerDirection {
   const factory ShimmerDirection.fromRBLT() = ShimmerDirection._fromRBLT;
 
   /// Animation starts from Left Center and moves towards the Right Center
-  const factory ShimmerDirection.fromLeftToRight() =
-      ShimmerDirection._fromLeftToRight;
+  const factory ShimmerDirection.fromLeftToRight() = ShimmerDirection._fromLeftToRight;
 
   /// Animation starts from Right Center and moves towards the Left Center
-  const factory ShimmerDirection.fromRightToLeft() =
-      ShimmerDirection._fromRightToLeft;
+  const factory ShimmerDirection.fromRightToLeft() = ShimmerDirection._fromRightToLeft;
 }

--- a/lib/src/shimmer_animator.dart
+++ b/lib/src/shimmer_animator.dart
@@ -11,6 +11,7 @@ class ShimmerAnimator extends StatefulWidget {
   final Duration interval;
   final ShimmerDirection direction;
   final Widget child;
+  final AnimationController? controller;
 
   ShimmerAnimator({
     required this.child,
@@ -19,6 +20,7 @@ class ShimmerAnimator extends StatefulWidget {
     required this.duration,
     required this.interval,
     required this.direction,
+    this.controller,
   });
 
   @override
@@ -26,8 +28,7 @@ class ShimmerAnimator extends StatefulWidget {
 }
 
 //Animator state controls the animation using all the parameters defined
-class _ShimmerAnimatorState extends State<ShimmerAnimator>
-  with TickerProviderStateMixin {
+class _ShimmerAnimatorState extends State<ShimmerAnimator> with TickerProviderStateMixin {
   late Animation<double> animation;
   late AnimationController controller;
   Timer? timer;
@@ -35,7 +36,7 @@ class _ShimmerAnimatorState extends State<ShimmerAnimator>
   @override
   void initState() {
     super.initState();
-    controller = AnimationController(vsync: this, duration: widget.duration);
+    controller = (widget.controller ?? AnimationController(vsync: this, duration: widget.duration));
     animation = Tween<double>(begin: 0, end: 1).animate(CurvedAnimation(
       parent: controller,
       curve: Interval(0, 0.6, curve: Curves.decelerate),


### PR DESCRIPTION
When using shimmer on elements in a ListView, each instance will end up creating an Animation controller. `animationController` will let you pass one from outside so that it can reused.